### PR TITLE
Largest cell count reset when resetting environment

### DIFF
--- a/src/Environments/WorldEnvironment.js
+++ b/src/Environments/WorldEnvironment.js
@@ -157,6 +157,7 @@ class WorldEnvironment extends Environment{
         this.renderer.renderFullGrid(this.grid_map.grid);
         this.total_mutability = 0;
         this.total_ticks = 0;
+        this.largest_cell_count = 0;
         FossilRecord.clear_record();
         if (reset_life)
             this.OriginOfLife();


### PR DESCRIPTION
fixed the event when you reset the environment, the largest cell count would not reset to 0.